### PR TITLE
Update metadata.json with the last gnome version until 46

### DIFF
--- a/spotify-controller@koolskateguy89/metadata.json
+++ b/spotify-controller@koolskateguy89/metadata.json
@@ -8,7 +8,9 @@
     "41",
     "42",
     "43",
-    "44"
+    "44",
+    "45",
+    "46"
   ],
   "settings-schema": "org.gnome.shell.extensions.spotify-controller",
   "url": "https://github.com/koolskateguy89/gnome-shell-extension-spotify-controller",


### PR DESCRIPTION
Just added the last versions to make it work on ubuntu 24 with gnome 46.